### PR TITLE
Don't follow symlinks on /dev/mapper devices

### DIFF
--- a/collectors.go
+++ b/collectors.go
@@ -101,12 +101,16 @@ func CollectDriveEvents(queue chan []Event) {
 			}
 
 			for _, match := range matches {
-				//resolve any symlinks to get the actual devicePath
-				devicePath, err := filepath.EvalSymlinks(match)
-				if err != nil {
-					Log(LogFatal, "readlink(%#v) failed: %s", match, err.Error())
+				devicePath := match
+				//don't follow /dev/mapper devices, because luks container created on the actual device
+				//still refer to the /dev/mapper one
+				if !strings.HasPrefix(match, "/dev/mapper") {
+					//resolve any symlinks to get the actual devicePath
+					devicePath, err = filepath.EvalSymlinks(match)
+					if err != nil {
+						Log(LogFatal, "readlink(%#v) failed: %s", match, err.Error())
+					}
 				}
-
 				//ignore devices with partitions
 				pattern := strings.TrimPrefix(devicePath+"[0-9]", "/")
 				submatches, err := filepath.Glob(pattern)

--- a/luks.go
+++ b/luks.go
@@ -123,21 +123,8 @@ func getBackingDevicePath(mapName string) string {
 	match := backingDeviceRx.FindStringSubmatch(stdout)
 	if match == nil {
 		Log(LogFatal, "cannot find backing device for /dev/mapper/%s", mapName)
-	} else {
-		//resolve any symlinks to get the actual devicePath
-		//when the luks container is created on top of multipathing, cryptsetup status might report the /dev/mapper/mapth device
-		//also the luksFormat was called on actual device
-		devicePath, err := filepath.EvalSymlinks(match[1])
-		if err != nil {
-			Log(LogFatal, "readlink(%#v) failed: %s", match, err.Error())
-		}
-		if devicePath != match[1] {
-			Log(LogDebug, "backing device path for %s is %s -> %s", mapName, match[1], devicePath)
-			return devicePath
-		} else {
-			Log(LogDebug, "backing device path for %s is %s", mapName, match[1])
-		}
 	}
+	Log(LogDebug, "backing device path for %s is %s", mapName, match[1])
 	return match[1]
 }
 


### PR DESCRIPTION
That is a follow up of: 3ec39f4b88a32f7635fd15b057495c59e96bc483

It is even saver to not follow symlinks on /dev/mapper devices during discovery
to ensure we are acting always on the same devices. It will solve the issue
with `luksformat` in conjunction with `multipathing`, where the device
`/dev/mapper/mpathX` is pointing to `/dev/dm-Y`, but `cryptsetup status` still refering
to `/dev/mapper/mpathX`.

//cc @majewsky also considering this as a quickfix, we should follow up...