### PR TITLE
support more durable broken flags in /var/lib/swift-storage/broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ written:
   `/var/lib/swift-storage/broken` to disable the device in a more durable way,
   once a disk hardware error has been confirmed.
 
+  The durable broken flag can also be created manually using the command
+  `ln -s /dev/sd$LETTER /var/lib/swift-storage/broken/$SERIAL`. The disk's
+  serial number can be found using `smartctl -d scsi -i /dev/sd$LETTER`.
+
 * Since the autopilot also does the job of `swift-drive-audit`, it honors its
   interface and writes `/var/cache/swift/drive.recon`. Drive errors detected by
   the autopilot will thus show up in `swift-recon --driveaudit`.

--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ written:
   log will explain why the device is considered broken, and how to reinstate the
   device into the cluster after resolving the issue.
 
+* `/var/lib/swift-storage/broken` has the same structure and semantics as
+  `/run/swift-storage/broken`, but its contents are retained across reboots. A
+  flag from `/run/swift-storage/broken` can be copied to
+  `/var/lib/swift-storage/broken` to disable the device in a more durable way,
+  once a disk hardware error has been confirmed.
+
 * Since the autopilot also does the job of `swift-drive-audit`, it honors its
   interface and writes `/var/cache/swift/drive.recon`. Drive errors detected by
   the autopilot will thus show up in `swift-recon --driveaudit`.

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func main() {
 		"/run/swift-storage/broken",
 		"/run/swift-storage/state/unmount-propagation",
 		"/var/cache/swift",
+		"/var/lib/swift-storage/broken",
 	)
 
 	//swift cache path must be accesible from user swift


### PR DESCRIPTION
With this, a broken flag can be persisted as follows:

```sh
cp /run/swift/storage-broken/$SERIAL_NUMBER /var/lib/swift-storage/broken
```